### PR TITLE
Add missing core entrypoints to trampoline.c

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -2614,3 +2614,24 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     disp->GetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
 }
+    
+LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
+                                 const VkAllocationCallbacks *pAllocator, VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    return disp->CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+}
+
+LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorUpdateTemplate(VkDevice device,
+                                                                           VkDescriptorUpdateTemplate descriptorUpdateTemplate,
+                                                                           const VkAllocationCallbacks *pAllocator) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    disp->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
+}
+
+LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
+                                                                           VkDescriptorUpdateTemplate descriptorUpdateTemplate,
+                                                                           const void *pData) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    disp->UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
+}


### PR DESCRIPTION
The entrypoints associated with VK_KHR_descriptor_update_template didn't
make it into the trampoline file when the extension was promoted to
core. This change adds them.

See Issue #2476